### PR TITLE
use programmatic vendor name per Jetbrains requirement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 ext {
-  vendorName = "IBM Global Cloud Acceleration Team"
+  vendorName = "IBM-GCAT"
   teamcityVersion = findProperty("teamcityVersion") ?: "2017.2"
 }
 


### PR DESCRIPTION
Got an email from Jetbrains asking us to make this change to comply with how they are handling vendor identification in their plugin repo